### PR TITLE
Add Elasticsearch configuration service

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -15,5 +15,9 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-elasticsearch</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/services/src/main/java/com/smoothOrg/services/elastic/ElasticsearchConfig.java
+++ b/services/src/main/java/com/smoothOrg/services/elastic/ElasticsearchConfig.java
@@ -1,0 +1,48 @@
+package com.smoothOrg.services.elastic;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticsearchConfig {
+
+    @Value("${elasticsearch.url}")
+    private String url;
+
+    @Value("${elasticsearch.username}")
+    private String username;
+
+    @Value("${elasticsearch.password}")
+    private String password;
+
+    @Bean
+    public RestClient restClient() {
+        RestClientBuilder builder = RestClient.builder(org.apache.http.HttpHost.create(url))
+            .setHttpClientConfigCallback(httpClientBuilder ->
+                httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider())
+            );
+        return builder.build();
+    }
+
+    private BasicCredentialsProvider credentialsProvider() {
+        BasicCredentialsProvider provider = new BasicCredentialsProvider();
+        provider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+        return provider;
+    }
+
+    @Bean
+    public ElasticsearchClient elasticsearchClient(RestClient restClient) {
+        ElasticsearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+        return new ElasticsearchClient(transport);
+    }
+}

--- a/services/src/main/java/com/smoothOrg/services/elastic/ElasticsearchService.java
+++ b/services/src/main/java/com/smoothOrg/services/elastic/ElasticsearchService.java
@@ -1,0 +1,11 @@
+package com.smoothOrg.services.elastic;
+
+import java.io.IOException;
+
+public interface ElasticsearchService {
+    boolean createIndex(String index) throws IOException;
+
+    boolean updateMapping(String index, String mappingJson) throws IOException;
+
+    String getDocument(String index, String id) throws IOException;
+}

--- a/services/src/main/java/com/smoothOrg/services/elastic/ElasticsearchServiceImpl.java
+++ b/services/src/main/java/com/smoothOrg/services/elastic/ElasticsearchServiceImpl.java
@@ -1,0 +1,58 @@
+package com.smoothOrg.services.elastic;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.GetRequest;
+import co.elastic.clients.elasticsearch.core.GetResponse;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
+import co.elastic.clients.elasticsearch.indices.CreateIndexResponse;
+import co.elastic.clients.elasticsearch.indices.PutMappingRequest;
+import co.elastic.clients.elasticsearch.indices.PutMappingResponse;
+import co.elastic.clients.json.JsonData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+@Service
+public class ElasticsearchServiceImpl implements ElasticsearchService {
+
+    private final ElasticsearchClient client;
+
+    @Autowired
+    public ElasticsearchServiceImpl(ElasticsearchClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public boolean createIndex(String index) throws IOException {
+        CreateIndexRequest request = new CreateIndexRequest.Builder()
+                .index(index)
+                .build();
+        CreateIndexResponse response = client.indices().create(request);
+        return response.acknowledged();
+    }
+
+    @Override
+    public boolean updateMapping(String index, String mappingJson) throws IOException {
+        PutMappingRequest request = new PutMappingRequest.Builder()
+                .index(index)
+                .withJson(new StringReader(mappingJson))
+                .build();
+        PutMappingResponse response = client.indices().putMapping(request);
+        return response.acknowledged();
+    }
+
+    @Override
+    public String getDocument(String index, String id) throws IOException {
+        GetRequest request = new GetRequest.Builder()
+                .index(index)
+                .id(id)
+                .build();
+        GetResponse<JsonData> response = client.get(request, JsonData.class);
+        if (response.found()) {
+            return response.source().to(String.class);
+        }
+        return null;
+    }
+}

--- a/web/src/main/java/com/smoothOrg/moneyAndTimeSaver/MoneyAndTimeSaverApplication.java
+++ b/web/src/main/java/com/smoothOrg/moneyAndTimeSaver/MoneyAndTimeSaverApplication.java
@@ -3,7 +3,7 @@ package com.smoothOrg.moneyAndTimeSaver;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.smoothOrg")
 public class MoneyAndTimeSaverApplication {
 
 	public static void main(String[] args) {

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=moneyAndTimeSaver
+elasticsearch.url=https://bb0decee35e24423a74a06a59992bc6c.us-central1.gcp.cloud.es.io/
+elasticsearch.username=elastic
+elasticsearch.password=GbJ5ILTo3zE4E3bnsKeeeube


### PR DESCRIPTION
## Summary
- configure Spring Boot scan for all `com.smoothOrg` packages
- add Elasticsearch starter to the services module
- add properties for connecting to the hosted Elasticsearch instance
- implement `ElasticsearchConfig` for creating an authenticated client
- create `ElasticsearchService` interface and `ElasticsearchServiceImpl`

## Testing
- `./mvnw -q test` *(fails: failed to fetch Maven due to lack of internet)*

------
https://chatgpt.com/codex/tasks/task_e_685d38edeb088331b5320ac482330336