### PR TITLE
Fix missing IndicesRecord class

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -20,5 +20,9 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-elasticsearch</artifactId>
         </dependency>
+        <dependency>
+            <groupId>co.elastic.clients</groupId>
+            <artifactId>elasticsearch-java</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- add `elasticsearch-java` dependency to services module

## Testing
- `./mvnw -q -pl services test` *(fails: Failed to fetch because the environment lacks internet access)*

------
https://chatgpt.com/codex/tasks/task_e_685d88c65b3883319d1fd7bb0976a947