### PR TITLE
Fix JSON string retrieval from Elasticsearch documents

### DIFF
--- a/services/src/main/java/com/smoothOrg/services/elastic/ElasticsearchServiceImpl.java
+++ b/services/src/main/java/com/smoothOrg/services/elastic/ElasticsearchServiceImpl.java
@@ -62,7 +62,7 @@ public class ElasticsearchServiceImpl implements ElasticsearchService {
                 .build();
         GetResponse<JsonData> response = client.get(request, JsonData.class);
         if (response.found()) {
-            return response.source().to(String.class);
+            return response.source().toString();
         }
         return null;
     }
@@ -100,7 +100,7 @@ public class ElasticsearchServiceImpl implements ElasticsearchService {
         SearchResponse<JsonData> response = client.search(request, JsonData.class);
         List<String> results = new ArrayList<>();
         for (Hit<JsonData> hit : response.hits().hits()) {
-            results.add(hit.source().to(String.class));
+            results.add(hit.source().toString());
         }
         return results;
     }


### PR DESCRIPTION
## Summary
- return search results as JSON strings instead of parsing them as `String`

## Testing
- `./mvnw -q test` *(fails: network access needed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d99d54c54833194987039c16548e7