### PR TITLE
Fix JSON serialization for Elasticsearch documents

### DIFF
--- a/services/src/main/java/com/smoothOrg/services/elastic/ElasticsearchServiceImpl.java
+++ b/services/src/main/java/com/smoothOrg/services/elastic/ElasticsearchServiceImpl.java
@@ -62,7 +62,10 @@ public class ElasticsearchServiceImpl implements ElasticsearchService {
                 .build();
         GetResponse<JsonData> response = client.get(request, JsonData.class);
         if (response.found()) {
-            return response.source().toString();
+            // Convert the JsonData payload to a JSON string rather than
+            // relying on the default toString implementation which only
+            // prints the underlying buffer object.
+            return response.source().to(String.class);
         }
         return null;
     }
@@ -100,7 +103,8 @@ public class ElasticsearchServiceImpl implements ElasticsearchService {
         SearchResponse<JsonData> response = client.search(request, JsonData.class);
         List<String> results = new ArrayList<>();
         for (Hit<JsonData> hit : response.hits().hits()) {
-            results.add(hit.source().toString());
+            // Convert each hit's JsonData into a JSON string.
+            results.add(hit.source().to(String.class));
         }
         return results;
     }


### PR DESCRIPTION
## Summary
- use `JsonData.to(String.class)` to properly serialize responses

## Testing
- `mvn -q -DskipTests` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d9be023f08331ab01ecbc06515d3b