### PR TITLE
Add Elasticsearch-backed product search endpoints

### DIFF
--- a/services/src/main/java/com/smoothOrg/services/elastic/ElasticsearchService.java
+++ b/services/src/main/java/com/smoothOrg/services/elastic/ElasticsearchService.java
@@ -28,4 +28,25 @@ public interface ElasticsearchService {
      * Retrieve all documents from the given index as JSON strings.
      */
     java.util.List<String> getAllDocuments(String index) throws IOException;
+
+    /**
+     * Perform a text based product search across commonly used product fields.
+     *
+     * @param index the index to search
+     * @param query the free-text query provided by the user
+     * @param size  optional number of documents to return (defaults applied by caller)
+     * @return the matching documents as maps containing their original fields
+     */
+    java.util.List<java.util.Map<String, Object>> searchProducts(String index, String query, Integer size) throws IOException;
+
+    /**
+     * Perform a text search for products limited to a specific geohash bucket.
+     *
+     * @param index   the index to search
+     * @param query   the free-text query provided by the user
+     * @param geohash the geohash code that should be matched
+     * @param size    optional number of documents to return (defaults applied by caller)
+     * @return the matching documents as maps containing their original fields
+     */
+    java.util.List<java.util.Map<String, Object>> searchProductsByGeohash(String index, String query, String geohash, Integer size) throws IOException;
 }

--- a/web/src/main/java/com/smoothOrg/web/controller/ProductSearchController.java
+++ b/web/src/main/java/com/smoothOrg/web/controller/ProductSearchController.java
@@ -1,0 +1,59 @@
+package com.smoothOrg.web.controller;
+
+import com.smoothOrg.services.elastic.ElasticsearchService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/products")
+public class ProductSearchController {
+
+    private final ElasticsearchService elasticsearchService;
+    private final String defaultIndex;
+
+    public ProductSearchController(ElasticsearchService elasticsearchService,
+                                   @Value("${app.elasticsearch.products-index:grocery_products_v1}") String defaultIndex) {
+        this.elasticsearchService = elasticsearchService;
+        this.defaultIndex = defaultIndex;
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ProductSearchResponse> searchProducts(
+            @RequestParam("query") String query,
+            @RequestParam(value = "size", required = false) Integer size,
+            @RequestParam(value = "index", required = false) String index) throws IOException {
+        String targetIndex = resolveIndex(index);
+        List<Map<String, Object>> results = elasticsearchService.searchProducts(targetIndex, query, size);
+        return ResponseEntity.ok(new ProductSearchResponse(targetIndex, query, null, results));
+    }
+
+    @GetMapping("/search/by-geohash")
+    public ResponseEntity<ProductSearchResponse> searchProductsByGeohash(
+            @RequestParam("query") String query,
+            @RequestParam("geohash") String geohash,
+            @RequestParam(value = "size", required = false) Integer size,
+            @RequestParam(value = "index", required = false) String index) throws IOException {
+        String targetIndex = resolveIndex(index);
+        List<Map<String, Object>> results = elasticsearchService.searchProductsByGeohash(targetIndex, query, geohash, size);
+        return ResponseEntity.ok(new ProductSearchResponse(targetIndex, query, geohash, results));
+    }
+
+    private String resolveIndex(String requestedIndex) {
+        return StringUtils.hasText(requestedIndex) ? requestedIndex : defaultIndex;
+    }
+
+    public record ProductSearchResponse(String index,
+                                        String query,
+                                        String geohash,
+                                        List<Map<String, Object>> results) {
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated product search controller with endpoints for text-only queries and geohash-filtered searches
- extend the Elasticsearch service with helpers that build multi-field product queries and execute searches

## Testing
- mvn -pl web -am compile *(fails: unable to download Spring Boot parent POM from Maven Central – HTTP 403 in sandbox environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f2c0ecafc833184b6a28a0a3fb1c2)